### PR TITLE
Digest Auth: Reauthenticate on 401.

### DIFF
--- a/lib/src/http_auth_digest.dart
+++ b/lib/src/http_auth_digest.dart
@@ -27,12 +27,6 @@ class DigestAuthClient extends http.BaseClient {
   }
 
   Future<http.StreamedResponse> send(http.BaseRequest request) async {
-    // after the first request we can provide Auth info
-    if (_auth.isReady()) {
-      _setAuthString(request);
-      return _inner.send(request);
-    }
-
     final response = await _inner.send(request);
 
     if (response.statusCode == 401) {


### PR DESCRIPTION
We're facing an issue in production where after while, the authentication expires on the server and we need to re-authenticate. This is the easiest way to fix the issue.